### PR TITLE
Prevent Item Loss on Duplicate Death Event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 *.war
 *.ear
 /target/
+
+# IDE Project Files
+.idea
+*.iml

--- a/src/main/java/com/mewin/WGKeepInvFlags/WGKIFlagListener.java
+++ b/src/main/java/com/mewin/WGKeepInvFlags/WGKIFlagListener.java
@@ -50,8 +50,13 @@ public class WGKIFlagListener implements Listener {
     {
         if(wgPlugin.getGlobalRegionManager().allows(WGKeepInventoryFlagsPlugin.KEEP_INVENTORY_FLAG, e.getEntity().getLocation(), wgPlugin.wrapPlayer(e.getEntity())))
         {
-            inventories.put(e.getEntity().getName(), e.getEntity().getInventory().getContents());
-            armors.put(e.getEntity().getName(), e.getEntity().getInventory().getArmorContents());
+            // Prevent overwriting inventories in the case of a duplicate death message
+            if (!inventories.containsKey(e.getEntity().getName())) {
+                inventories.put(e.getEntity().getName(), e.getEntity().getInventory().getContents());
+            }
+            if (!armors.containsKey(e.getEntity().getName())) {
+                armors.put(e.getEntity().getName(), e.getEntity().getInventory().getArmorContents());
+            }
             e.getDrops().clear();
         }
         


### PR DESCRIPTION
If a player is damaged more than once in a tick, more than one death event can get sent.

In this case, the plugin would lose the players' items (and avoid dropping them!) since it overwrites the stored inventory with the player's empty inventory on the second death event.

This fixes that case by checking for an existing stored inventory on death, and not overwriting it if one is found.
